### PR TITLE
fixing compose report service report-api depends_on and docker networ…

### DIFF
--- a/defense_center/compose.opencti-connector.yml
+++ b/defense_center/compose.opencti-connector.yml
@@ -5,7 +5,7 @@ name: mataelang-opencti-connector
 networks:
   default:
     external:
-      name: mataelang
+      name: mataelang_default
 
 services:
   opencti-connector-aggregator:

--- a/defense_center/compose.reporting.yml
+++ b/defense_center/compose.reporting.yml
@@ -5,7 +5,7 @@ name: mataelang-reporting
 networks:
   default:
     external:
-      name: mataelang
+      name: mataelang_default
 
 volumes:
   postgresql_data:
@@ -85,7 +85,7 @@ services:
           condition: service_healthy
       chromium:
           condition: service_started
-      web:
+      report-api-web:
           condition: service_started
       iplookup-api:
           condition: service_started


### PR DESCRIPTION
This pull request includes changes to the `defense_center/compose.opencti-connector.yml` and `defense_center/compose.reporting.yml` files to update network names and service conditions. The most important changes include updating network names to `mataelang_default` and renaming the `web` service to `report-api-web`.

Network name updates:
* [`defense_center/compose.opencti-connector.yml`](diffhunk://#diff-c45e63126134c31896c72d3b044666b3c96df340441650016fe9cb59eb419196L8-R8): Changed the network name from `mataelang` to `mataelang_default`.
* [`defense_center/compose.reporting.yml`](diffhunk://#diff-fcac7a138f7f3605f97cc40da6ea8c1f1135232bee99928c7ffc8348ba213d0bL8-R8): Changed the network name from `mataelang` to `mataelang_default`.

Service condition updates:
* [`defense_center/compose.reporting.yml`](diffhunk://#diff-fcac7a138f7f3605f97cc40da6ea8c1f1135232bee99928c7ffc8348ba213d0bL88-R88): Renamed the `web` service to `report-api-web` to clarify its purpose.…k for compose reporting and opencti-connector