### PR TITLE
Unify SSL Script

### DIFF
--- a/defense_center/.env.example
+++ b/defense_center/.env.example
@@ -21,3 +21,6 @@ OPENSEARCH_INITIAL_ADMIN_PASSWORD=SecurePassword@123
 # SSL_PASSWORD is the password used to secure SSL connections.
 SSL_PASSWORD=SecurePassword@123
 
+HOST_UID=1000
+HOST_GID=1000
+

--- a/defense_center/certs/event-stream-aggr-creds/event-stream-aggr.cnf
+++ b/defense_center/certs/event-stream-aggr-creds/event-stream-aggr.cnf
@@ -1,17 +1,13 @@
 [req]
-default_bits = 2048
-prompt = no
-default_md = sha256
-distinguished_name = dn
+distinguished_name = req_distinguished_name
 req_extensions = v3_req
+prompt = no
 
-[dn]
-C = ID
-ST = EastJava
-L = Surabaya
+[req_distinguished_name]
+C = US
 O = MATAELANG
-OU = CSRG
-CN = opensearch-node1
+L = MountainView
+CN = event-stream-aggr
 
 [v3_req]
 keyUsage = keyEncipherment, dataEncipherment, digitalSignature
@@ -19,6 +15,6 @@ extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [alt_names]
-DNS.1 = opensearch-node1
+DNS.1 = event-stream-aggr
 DNS.2 = localhost
 IP.1 = 127.0.0.1

--- a/defense_center/certs/kafka-ui-creds/kafka-ui.cnf
+++ b/defense_center/certs/kafka-ui-creds/kafka-ui.cnf
@@ -1,17 +1,13 @@
 [req]
-default_bits = 2048
-prompt = no
-default_md = sha256
-distinguished_name = dn
+distinguished_name = req_distinguished_name
 req_extensions = v3_req
+prompt = no
 
-[dn]
-C = ID
-ST = EastJava
-L = Surabaya
+[req_distinguished_name]
+C = US
 O = MATAELANG
-OU = CSRG
-CN = opensearch-node1
+L = MountainView
+CN = kafka-ui
 
 [v3_req]
 keyUsage = keyEncipherment, dataEncipherment, digitalSignature
@@ -19,6 +15,6 @@ extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [alt_names]
-DNS.1 = opensearch-node1
+DNS.1 = kafka-ui
 DNS.2 = localhost
 IP.1 = 127.0.0.1

--- a/defense_center/certs/logstash-creds/logstash.cnf
+++ b/defense_center/certs/logstash-creds/logstash.cnf
@@ -1,17 +1,13 @@
 [req]
-default_bits = 2048
-prompt = no
-default_md = sha256
-distinguished_name = dn
+distinguished_name = req_distinguished_name
 req_extensions = v3_req
+prompt = no
 
-[dn]
-C = ID
-ST = EastJava
-L = Surabaya
+[req_distinguished_name]
+C = US
 O = MATAELANG
-OU = CSRG
-CN = opensearch-node1
+L = MountainView
+CN = logstash
 
 [v3_req]
 keyUsage = keyEncipherment, dataEncipherment, digitalSignature
@@ -19,6 +15,6 @@ extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [alt_names]
-DNS.1 = opensearch-node1
+DNS.1 = logstash
 DNS.2 = localhost
 IP.1 = 127.0.0.1

--- a/defense_center/certs/sensor-api-creds/sensor-api.cnf
+++ b/defense_center/certs/sensor-api-creds/sensor-api.cnf
@@ -1,17 +1,13 @@
 [req]
-default_bits = 2048
-prompt = no
-default_md = sha256
-distinguished_name = dn
+distinguished_name = req_distinguished_name
 req_extensions = v3_req
+prompt = no
 
-[dn]
-C = ID
-ST = EastJava
-L = Surabaya
+[req_distinguished_name]
+C = US
 O = MATAELANG
-OU = CSRG
-CN = opensearch-node1
+L = MountainView
+CN = sensor-api
 
 [v3_req]
 keyUsage = keyEncipherment, dataEncipherment, digitalSignature
@@ -19,6 +15,6 @@ extendedKeyUsage = serverAuth, clientAuth
 subjectAltName = @alt_names
 
 [alt_names]
-DNS.1 = opensearch-node1
+DNS.1 = sensor-api
 DNS.2 = localhost
 IP.1 = 127.0.0.1

--- a/defense_center/compose.yml
+++ b/defense_center/compose.yml
@@ -17,6 +17,8 @@ services:
       - SSL_PASSWORD=${SSL_PASSWORD:-SecurePassword@123}
       - CERT_VALIDITY_DAYS=365
       - CERT_RENEW_THRESHOLD_DAYS=60
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
     env_file:
       - .env
     volumes:
@@ -29,6 +31,7 @@ services:
       - ./certs/event-stream-aggr-creds:/work/certs/event-stream-aggr-creds
       - ./certs/sensor-api-creds:/work/certs/sensor-api-creds
       - ./certs/logstash-creds:/work/certs/logstash-creds
+      - ./certs/opensearch:/work/certs/opensearch
 
   sensor-api:
     image: ghcr.io/mata-elang-stable/sensor-snort-service:latest

--- a/defense_center/scripts/generate-broker-mtls-certs.sh
+++ b/defense_center/scripts/generate-broker-mtls-certs.sh
@@ -227,7 +227,7 @@ create_schema_registry_creds() {
         -passin pass:$SSL_PASSWORD \
         -extensions v3_req
 
-    # Export PKCS12 including only server cert + CA cert (do NOT include CA private key)
+    # Export PKCS12
     openssl pkcs12 -export \
         -in ${cert}-creds/${cert}.crt \
         -inkey ${cert}-creds/${cert}.key \
@@ -237,7 +237,6 @@ create_schema_registry_creds() {
         -out ${cert}-creds/${cert}.p12 \
         -password pass:$SSL_PASSWORD
     
-    # Make .p12 file readable
     chmod 644 ${cert}-creds/${cert}.p12
 
     # Convert to JKS keystore for Schema Registry
@@ -258,21 +257,7 @@ create_schema_registry_creds() {
 }
 
 # ========================
-# Main
-# ========================
-create_ca
-
-# Broker creds
-for cert in "broker"; do
-    create_broker_creds ${cert}
-done
-
-# Schema Registry creds
-create_schema_registry_creds
-
-# ========================
-# Create client (service) credentials (PEM and PKCS12 and JKS for Java clients)
-# Uses an existing cnf file in ${cert}-creds/${cert}.cnf, like the broker and schema-registry
+# Create client (service) credentials
 # ========================
 create_client_creds() {
     local cert=$1
@@ -307,7 +292,7 @@ create_client_creds() {
         -passin pass:$SSL_PASSWORD \
         -extensions v3_req
 
-    # Export PKCS12 for client use
+    # Export PKCS12
     openssl pkcs12 -export \
         -in ${cert}-creds/${cert}.crt \
         -inkey ${cert}-creds/${cert}.key \
@@ -317,11 +302,9 @@ create_client_creds() {
         -out ${cert}-creds/${cert}.p12 \
         -password pass:$SSL_PASSWORD
     
-    # Make .p12 file readable by services
     chmod 644 ${cert}-creds/${cert}.p12
 
     if [ "${make_jks}" = "true" ]; then
-        # Convert to JKS for Java clients
         keytool -importkeystore \
             -deststorepass $SSL_PASSWORD \
             -destkeystore ${cert}-creds/${cert}-keystore.jks \
@@ -338,7 +321,109 @@ create_client_creds() {
     CHANGES_MADE=1
 }
 
-# Create a few default client credentials for services that will connect to Kafka
+# ========================
+# Create OpenSearch Credentials
+# OpenSearch Security Plugin uses raw PEM files, not JKS/PKCS12.
+# Files must match exactly what is declared in opensearch-node1 environment:
+#   pemcert_filepath   = certificates/opensearch-node1.pem
+#   pemkey_filepath    = certificates/opensearch-node1-key.pem
+#   pemtrustedcas_filepath = certificates/root-ca.pem
+# ========================
+create_opensearch_creds() {
+    local dir="opensearch"
+    local cert_file="${dir}/opensearch-node1.pem"
+
+    if ! check_cert_needs_renewal "$cert_file"; then
+        return
+    fi
+
+    echo "Creating OpenSearch SSL credentials..."
+    mkdir -p "$dir"
+
+    # Reuse the shared CA as the OpenSearch trusted CA
+    # opensearch-node1 mounts ./certs/opensearch -> /usr/share/opensearch/config/certificates
+    # so root-ca.pem must live inside that directory
+    cp ca-creds/ca.crt "${dir}/root-ca.pem"
+
+    # Use existing CNF if present (./certs/opensearch/opensearch-node.cnf)
+    # Otherwise generate a default one
+    local cnf="${dir}/opensearch-node.cnf"
+    if [ ! -f "$cnf" ]; then
+        echo "opensearch-node.cnf not found, generating default..."
+        cat > "$cnf" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+C = ID
+O = MataElang
+CN = opensearch-node1
+
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment, digitalSignature
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = opensearch-node1
+DNS.2 = localhost
+IP.1 = 127.0.0.1
+EOF
+    fi
+
+    # Generate node private key
+    openssl genrsa -out "${dir}/opensearch-node1-key.pem" 2048
+
+    # Generate CSR
+    openssl req -new \
+        -key "${dir}/opensearch-node1-key.pem" \
+        -out "${dir}/opensearch-node1.csr" \
+        -config "$cnf"
+
+    # Sign with shared CA
+    openssl x509 -req \
+        -days $VALIDITY_DAYS \
+        -in "${dir}/opensearch-node1.csr" \
+        -CA ca-creds/ca.crt \
+        -CAkey ca-creds/ca.key \
+        -CAcreateserial \
+        -out "${dir}/opensearch-node1.pem" \
+        -extfile "$cnf" \
+        -extensions v3_req
+
+    # Cleanup CSR — not needed after signing
+    rm -f "${dir}/opensearch-node1.csr"
+
+    # OpenSearch runs as UID 1000 inside the container
+    # key must be 600, certs 644
+    chown ${HOST_UID:-1000}:${HOST_GID:-1000} "${dir}/root-ca.pem"
+    chown ${HOST_UID:-1000}:${HOST_GID:-1000} "${dir}/opensearch-node1.pem"
+    chown ${HOST_UID:-1000}:${HOST_GID:-1000} "${dir}/opensearch-node1-key.pem"
+
+    chmod 644 "${dir}/root-ca.pem"
+    chmod 644 "${dir}/opensearch-node1.pem"
+    chmod 640 "${dir}/opensearch-node1-key.pem"
+
+    echo "OpenSearch SSL credentials created."
+    CHANGES_MADE=1
+}
+
+# ========================
+# Main
+# ========================
+create_ca
+
+# Broker
+for cert in "broker"; do
+    create_broker_creds ${cert}
+done
+
+# Schema Registry
+create_schema_registry_creds
+
+# Kafka clients
 for client in "event-stream-aggr" "sensor-api" "kafka-ui" "logstash"; do
     if [ "$client" = "kafka-ui" ] || [ "$client" = "logstash" ]; then
         create_client_creds ${client} true
@@ -347,8 +432,8 @@ for client in "event-stream-aggr" "sensor-api" "kafka-ui" "logstash"; do
     fi
 done
 
-# Save truststore creds
-# echo $SSL_PASSWORD > truststore_creds # Moved to create_ca
+# OpenSearch
+create_opensearch_creds
 
 if [ $CHANGES_MADE -eq 1 ]; then
     echo "Certificates generated or renewed."


### PR DESCRIPTION
This pull request introduces significant improvements to the certificate management and service configuration for the Defense Center. The main focus is on adding automated OpenSearch SSL certificate generation, updating service and client certificate configuration files, and improving Docker Compose and environment variable handling for better container compatibility.

Key changes include:

**OpenSearch SSL Certificate Automation:**
- Added a new `create_opensearch_creds` function to `generate-broker-mtls-certs.sh` that automates the generation and renewal of OpenSearch node certificates, including proper permissions and file placement. This ensures OpenSearch uses the correct PEM files and trusted CA, aligning with its security plugin requirements. (Fe2c17d4R321)
- Updated `defense_center/certs/opensearch/opensearch-node.cnf` to set the correct `CN`, add key usage and extended key usage fields, and adjust SANs for local development.

**Docker and Environment Variable Improvements:**
- Introduced `HOST_UID` and `HOST_GID` environment variables in `.env.example` and referenced them in `compose.yml` to ensure generated certificate files have the correct ownership for containerized OpenSearch. [[1]](diffhunk://#diff-25d0e4979c9416a7ae24094694dd06e5531dec86223af8dd813d308d9ed8a377R24-R26) [[2]](diffhunk://#diff-4025951b1a9df243c65a1dc2680df23e4c6138616b96c8e626f78beb799d7f6eR20-R21)
- Updated Docker Compose volumes to mount the new `opensearch` certificate directory into the OpenSearch container, ensuring the service has access to its required credentials.

**Certificate Script Refactoring and Cleanup:**
- Refactored the certificate generation script to clarify the main execution flow, group related logic, and remove redundant comments. This improves maintainability and readability. [[1]](diffhunk://#diff-ffa33d0ab359ffaaa6b99f77bd77def2460abf6294baf2bc1d375d80561670a6L261-R260) [[2]](diffhunk://#diff-ffa33d0ab359ffaaa6b99f77bd77def2460abf6294baf2bc1d375d80561670a6L341-R426)
- Minor adjustments to PKCS12 export steps and permissions to standardize how certificates are handled for both server and client credentials. [[1]](diffhunk://#diff-ffa33d0ab359ffaaa6b99f77bd77def2460abf6294baf2bc1d375d80561670a6L230-R230) [[2]](diffhunk://#diff-ffa33d0ab359ffaaa6b99f77bd77def2460abf6294baf2bc1d375d80561670a6L240) [[3]](diffhunk://#diff-ffa33d0ab359ffaaa6b99f77bd77def2460abf6294baf2bc1d375d80561670a6L310-R295) [[4]](diffhunk://#diff-ffa33d0ab359ffaaa6b99f77bd77def2460abf6294baf2bc1d375d80561670a6L320-L324)

These changes collectively improve security, automation, and developer experience for managing SSL certificates in the Defense Center environment.