### PR TITLE
refactor: externalize environment variables and update service configs

### DIFF
--- a/defense_center/.env.example
+++ b/defense_center/.env.example
@@ -1,6 +1,59 @@
 ###################################################
 # Mata Elang Core Defense Center configuration file.
 ###################################################
+
+
+###################################################
+# Sensor API configuration
+###################################################
+
+# gRPC server listen address (default: 0.0.0.0)
+MES_SERVER_HOST=0.0.0.0
+
+# gRPC server port (default: 50051)
+MES_SERVER_PORT=50051
+
+# Kafka broker addresses, comma-separated (default: kafka:9092)
+MES_SERVER_KAFKA_BROKERS=broker:19094
+
+# Kafka topic to publish sensor events to (default: sensor_events)
+MES_SERVER_KAFKA_TOPIC=sensor_events
+
+# Schema Registry URL (default: http://schema-registry:8081)
+MES_SERVER_SCHEMA_REGISTRY_URL=https://schema-registry:8081
+
+# Kafka security protocol: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL (default: PLAINTEXT)
+MES_SERVER_SECURITY_PROTOCOL=PLAINTEXT
+
+# Maximum gRPC message size in MB (default: 100)
+MES_SERVER_MAX_MESSAGE_SIZE=1024
+
+# -- TLS/mTLS (optional, uncomment if needed) --
+# Enable TLS for gRPC server (default: false)
+#MES_SERVER_SECURE=true
+
+# Path to TLS certificate file (no default)
+#MES_SERVER_CERTIFICATE=/secrets/server.crt
+
+# Path to TLS key file (no default)
+#MES_SERVER_KEY=/secrets/server.key
+
+# Path to CA certificate for Kafka mTLS (no default)
+#MES_SERVER_PATH_TO_CA=/secrets/ca.crt
+
+# Path to client PKCS#12 keystore for Kafka mTLS (no default)
+#MES_SERVER_PATH_TO_CLIENT_KEYSTORE=/secrets/client.p12
+
+# Password for client PKCS#12 keystore (no default)
+#MES_SERVER_CLIENT_KEYSTORE_PASSWORD=SslSecurePassword@123
+
+# Increase log verbosity: 1=debug, 2+=trace (default: 0)
+#MES_SERVER_VERBOSE=0
+
+###################################################
+# Opensearch configuration
+###################################################
+
 # OPENSEARCH_INITIAL_ADMIN_PASSWORD is the password for the initial admin user created in the OpenSearch instance.
 # It is used to authenticate the Defense Center with OpenSearch.
 OPENSEARCH_INITIAL_ADMIN_PASSWORD=SecurePassword@123

--- a/defense_center/compose.yml
+++ b/defense_center/compose.yml
@@ -50,19 +50,8 @@ services:
     volumes:
       - ./certs/ca-creds/ca.pem:/app/ca.pem:ro
       - ./certs/sensor-api-creds/sensor-api.p12:/app/sensor-client.p12:ro
-    environment:
-      - MES_SERVER_HOST=0.0.0.0
-      - MES_SERVER_PORT=50051
-      - MES_SERVER_INSECURE=true
-      - MES_SERVER_MAX_MESSAGE_SIZE=1024
-      - MES_SERVER_KAFKA_BROKERS=broker:19094
-      - MES_SERVER_SCHEMA_REGISTRY_URL=https://schema-registry:8081
-      - MES_SERVER_KAFKA_GROUP_ID=sensor-api
-      - MES_SERVER_KAFKA_TOPIC=sensor_events
-      - MES_SERVER_SECURITY_PROTOCOL=SSL
-      - MES_SERVER_PATH_TO_CA=/app/ca.pem
-      - MES_SERVER_PATH_TO_CLIENT_KEYSTORE=/app/sensor-client.p12
-      - MES_SERVER_CLIENT_KEYSTORE_PASSWORD=${SSL_PASSWORD:-SslSecurePassword@123}
+    env_file:
+      - .env
     deploy:
       resources:
         limits:

--- a/sensor_snort/.env.example
+++ b/sensor_snort/.env.example
@@ -60,3 +60,34 @@ MES_CLIENT_PORT=50051
 # Unique ID of the sensor in the MES server
 # default: sensor1
 MES_CLIENT_SENSOR_ID=sensor1
+
+# Path to Snort alert JSON file (default: /var/log/snort/alert_json.txt)
+MES_CLIENT_FILE=/var/log/snort/alert_json.txt
+
+# Path to Snort alert unix socket — mutually exclusive with MES_CLIENT_FILE
+# MES_CLIENT_SOCKET=/var/log/snort/alert.sock
+
+# Interval between batch sends to gRPC server (default: 1s)
+MES_CLIENT_INTERVAL=1
+
+# Maximum concurrent gRPC stream clients (default: 10)
+MES_CLIENT_MAX_CLIENTS=10
+
+# Maximum gRPC message size in MB (default: 100)
+MES_CLIENT_MAX_MESSAGE_SIZE=100
+
+# -- TLS (optional, uncomment if server uses TLS) --
+# Enable TLS for gRPC client connection (default: false)
+#MES_CLIENT_SECURE=true
+
+# Path to TLS CA certificate for server verification (no default)
+#MES_CLIENT_CERTIFICATE=/secrets/ca.crt
+
+# Server name for TLS hostname verification (no default)
+#MES_CLIENT_SERVER_NAME=mes-snort-server
+
+# Enable testing mode — forces insecure connection, skips TLS verification (default: false)
+#MES_CLIENT_TESTING_MODE=true
+
+# Increase log verbosity: 1=debug, 2+=trace (default: 0)
+#MES_CLIENT_VERBOSE=0

--- a/sensor_snort/compose.yml
+++ b/sensor_snort/compose.yml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   snort:
-    image: ghcr.io/mata-elang-stable/snort3-docker-image:v2.0-debian
+    image: ghcr.io/mata-elang-stable/snort3-docker-image:main-debian
     restart: unless-stopped
     network_mode: host
     env_file:
@@ -28,7 +28,11 @@ services:
 
   snort-parser:
     image: ghcr.io/mata-elang-stable/sensor-snort-service:latest
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     restart: unless-stopped
+    container_name: snort-parser
     command: "client -v"
     depends_on:
       - snort


### PR DESCRIPTION
## Summary
- Move hardcoded environment variables from `compose.yml` to `.env` files for
  `defense_center` and `sensor_snort` services
- Add new configuration options for TLS/mTLS, gRPC, verbose logging, and sensor
  client settings
- Update snort Docker image tag from `v2.0-debian` to `main-debian`

## Changes
| File | Change |
|------|--------|
| `defense_center/.env.example` | Add Sensor API (gRPC, Kafka, TLS) and OpenSearch env vars |
| `defense_center/compose.yml` | Replace inline `environment:` with `env_file: .env` |
| `sensor_snort/.env.example` | Add client env vars (file/socket, TLS, verbose, interval) |
| `sensor_snort/compose.yml` | Update snort image tag, add `container_name` |

## Why
Centralizing configuration in `.env` files makes it easier to customize per
deployment without modifying compose files. Also unlocks new features like
TLS/mTLS and verbose logging.